### PR TITLE
handle openssl 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.1
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 script:
   - bundle exec rake build_libsecp256k1
   - bundle exec rake rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bitcoin-ruby (0.0.18)
+    bitcoin-ruby (0.0.20)
       eventmachine
       ffi
       scrypt
@@ -82,4 +82,4 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/README.rdoc
+++ b/README.rdoc
@@ -13,11 +13,9 @@ Some of the main features are:
 
 == Compatible with...
 
-* ruby 1.9.3
-* ruby 2.0.0
-* ruby 2.1.2
-* ruby 2.2.0
-* ruby 2.2.2
+* ruby 2.4.x
+* ruby 2.5.x
+* ruby 2.6.x
 
 == Installation
 

--- a/lib/bitcoin/version.rb
+++ b/lib/bitcoin/version.rb
@@ -1,3 +1,3 @@
 module Bitcoin
-  VERSION = "0.0.19"
+  VERSION = "0.0.20"
 end


### PR DESCRIPTION
* uses fixes from here https://github.com/se3000/ruby-eth/pull/42
* replaces regenerate_key ffi code with pure-ruby openssl code.
* removes unused der_to_private_key method.